### PR TITLE
Find active editor through atom on save

### DIFF
--- a/lib/nsync/atom-helper.coffee
+++ b/lib/nsync/atom-helper.coffee
@@ -88,6 +88,10 @@ module.exports = helper =
 
     document.title = title
 
+  convertToLF: ->
+    view = atom.views.getView(atom.workspace)
+    atom.commands.dispatch(view, 'line-ending-selector:convert-to-LF')
+
   treeView: ->
     pkg = atom.packages.getActivePackage(name)
     pkg?.mainModule.treeView

--- a/lib/nsync/atom-helper.coffee
+++ b/lib/nsync/atom-helper.coffee
@@ -88,10 +88,6 @@ module.exports = helper =
 
     document.title = title
 
-  convertToLF: ->
-    view = atom.views.getView(atom.workspace)
-    atom.commands.dispatch(view, 'line-ending-selector:convert-to-LF')
-
   treeView: ->
     pkg = atom.packages.getActivePackage(name)
     pkg?.mainModule.treeView

--- a/lib/nsync/atom-helper.coffee
+++ b/lib/nsync/atom-helper.coffee
@@ -159,8 +159,8 @@ module.exports = helper =
   observeTextEditors: (callback) ->
     atom.workspace.observeTextEditors(callback)
 
-  findTextEditorByElement: (element) ->
-    element.getModel()
+  findActiveTextEditor: ->
+    atom.workspace.getActiveTextEditor()
 
   findTextEditorByPath: (path) ->
     atom.workspace.getTextEditors().find (editor) ->

--- a/lib/nsync/initializer.coffee
+++ b/lib/nsync/initializer.coffee
@@ -51,10 +51,13 @@ onSave = ->
     # TODO: untitled editor is saved
     return console.warn 'Cannot save file without path'
 
-  if process.platform is 'win32'
-    atomHelper.convertToLF()
-
   text = convertEOL(editor.getText())
+
+  if process.platform is 'win32'
+    buffer = editor.getBuffer()
+    buffer.setPreferredLineEnding('\n')
+    buffer.setText(text)
+
   content = new Buffer(text).toString('base64')
   nsync.save(path, content)
 

--- a/lib/nsync/initializer.coffee
+++ b/lib/nsync/initializer.coffee
@@ -51,6 +51,9 @@ onSave = ->
     # TODO: untitled editor is saved
     return console.warn 'Cannot save file without path'
 
+  if process.platform is 'win32'
+    atomHelper.convertToLF()
+
   text = convertEOL(editor.getText())
   content = new Buffer(text).toString('base64')
   nsync.save(path, content)

--- a/lib/nsync/initializer.coffee
+++ b/lib/nsync/initializer.coffee
@@ -45,7 +45,7 @@ onRefresh = ->
 
 onSave = ->
   editor = atomHelper.findActiveTextEditor()
-  path = editor.getPath()
+  path = editor?.getPath()
 
   if not path
     # TODO: untitled editor is saved

--- a/lib/nsync/initializer.coffee
+++ b/lib/nsync/initializer.coffee
@@ -43,8 +43,8 @@ unimplemented = ({type}) ->
 onRefresh = ->
   atomHelper.resetPackage()
 
-onSave = ({target}) ->
-  editor = atomHelper.findTextEditorByElement(target)
+onSave = ->
+  editor = atomHelper.findActiveTextEditor()
   path = editor.getPath()
 
   if not path


### PR DESCRIPTION
see https://github.com/learn-co/learn-ide/issues/425

should be released with learn-ide@2.5.0

While working on this, I also discovered that line endings were causing trouble with save on Windows. Basically, we switch to LF from CRLF before sending a file to the server, and it is then sent back to the local disk in LF; however, the buffer still thinks it should be CRLF, so the file stays "dirty" (looks like it hasn't saved). This now updates the contents of the buffer *before* sending the file to the server, so that as soon as it gets back, the text buffer will recognize that it is in sync with the disk contents.