### PR TITLE
Prepare for single websocket connection

### DIFF
--- a/lib/nsync/initializer.coffee
+++ b/lib/nsync/initializer.coffee
@@ -25,7 +25,7 @@ WS_SERVER_URL = (->
   ,
     host: 'ile.learn.co',
     port: 443,
-    path: 'fs_server'
+    path: 'environment'
 
   {host, port, path} = config
   protocol = if port is 443 then 'wss' else 'ws'
@@ -204,6 +204,7 @@ module.exports = helper = (activationState) ->
         localRoot: _path.join(atom.configDirPath, '.learn-ide')
         connection:
           url: "#{WS_SERVER_URL}?token=#{token}&version=#{atomHelper.learnIdeVersion()}"
+          socketKey: 'environment'
 
   atomHelper.waitForTerminalConnection().then(connect).catch(connect)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2.3.0",
     "minimatch": "~0.3.0",
-    "nsync-fs": "0.0.21",
+    "nsync-fs": "0.0.22",
     "temp": "~0.8.1",
     "underscore-plus": "^1.0.0"
   },


### PR DESCRIPTION
Dependent on https://github.com/learn-co/nsync-fs/pull/16. Once the `nsync-fs` change is published, the package version should be updated here.

Related: https://github.com/learn-co/learn-ide/pull/493

