### PR TITLE
Remove caching of nsync

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -42,7 +42,6 @@ module.exports =
     })
 
   deactivate: ->
-    nsync.cache() unless @preventCache
     @disposables.dispose()
     @nsyncDisposables.dispose()
     @fileIconsDisposable?.dispose()

--- a/lib/nsync/initializer.coffee
+++ b/lib/nsync/initializer.coffee
@@ -162,8 +162,6 @@ module.exports = helper = (activationState) ->
 
     atomHelper.on 'learn-ide:logout', ->
       pkg = atom.packages.loadPackage(name)
-      pkg.mainModule.preventCache = true
-      nsync.flushCache()
 
     atomHelper.onDidActivatePackage (pkg) ->
       if pkg.name is 'find-and-replace'


### PR DESCRIPTION
As the IDE will now be scoped to a particular lab, the tree now differs on each load and it should never be loaded from a cache. Also, the initial tree will always be much smaller, so the benefit of the cache is kinda whatevs.

Related:
- https://github.com/learn-co/nsync-fs/pull/20